### PR TITLE
Fix for timestamp calculation

### DIFF
--- a/plugin/pad.py
+++ b/plugin/pad.py
@@ -14,6 +14,7 @@ def pad_timestamp():
 	return str(int(time.time() * 1000000))
 
 def pad_natural_timestamp(timestamp):
+	timestamp = basename(timestamp)
 	f_timestamp = float(int(timestamp)) / 1000000
 	tmp_datetime = datetime.datetime.fromtimestamp(f_timestamp)
 	diff = datetime.datetime.now() - tmp_datetime


### PR DESCRIPTION
For some reason vim-pad wasn't working for me on my mac. The problem was that the full path was being passed into float(), which obviously doesn't work. A call to basename seems to fix it.
