### PR TITLE
Don't ruin existing listchars.

### DIFF
--- a/ftplugin/pad.vim
+++ b/ftplugin/pad.vim
@@ -2,7 +2,7 @@ setlocal cursorline
 setlocal buftype=nofile
 setlocal noswapfile
 setlocal nowrap
-setlocal listchars=extends:…,precedes:…
+setlocal listchars+=extends:…,precedes:…
 setlocal nomodified
 setlocal conceallevel=2
 setlocal concealcursor=nc


### PR DESCRIPTION
It is a global-only option. `setlocal` is as good as `set`.

Without this fix, the existing setting for `listchars` is overwritten and this applies to all buffers. This is very annoying for those who use `set list`.
