### PR TITLE
Fixes for the notes list

### DIFF
--- a/plugin/padlib/list_local.py
+++ b/plugin/padlib/list_local.py
@@ -117,7 +117,7 @@ def sort(key="1"): #{{{1
 
     key = SORT_TYPES[key]
     if key=="date":
-        vim.command("call pad#ListPads('')")
+        vim.command("ListPads")
         return
 
     tuples = []


### PR DESCRIPTION
3 fixes for the notes list sorting
1. Don't do anything when the sorting type is unknown (i.e. not 1,2,3)
2. Tag sorting was using get_save_dir() + pad_id resulting in a doubled path
3. Fix call to ListPads when sorting by date
