### PR TITLE
declare `:Pad` as taking one or more arguments.

### DIFF
--- a/plugin/pad.vim
+++ b/plugin/pad.vim
@@ -115,7 +115,7 @@ endif
 " Commands: {{{1
 "
 " Creates a new note
-command! -nargs=? -bang -complete=custom,pad#PadCmdComplete Pad call pad#PadCmd('<args>', '<bang>')
+command! -nargs=+ -bang -complete=custom,pad#PadCmdComplete Pad call pad#PadCmd('<args>', '<bang>')
 command! -nargs=? -bang ListPads call pad#PadCmd('ls <args>', '<bang>')
 command! -nargs=? OpenPad call pad#PadCmd('new <args>', '')
 


### PR DESCRIPTION
Avoids ugly excpetion when calling just `:Pad`