### PR TITLE
Fix for ack.

### DIFF
--- a/pythonx/vim_pad/handler.py
+++ b/pythonx/vim_pad/handler.py
@@ -147,7 +147,8 @@ def listdir_external(path, archive, query): # {{{1
     if bool(int(vim.eval("g:pad#search_ignorecase"))):
         command.append("-i")
 
-    command.append("--max-count=1")
+    if search_backend != "ack":
+        command.append("--max-count=1")
 
     cmd_output = Popen(command, stdout=PIPE, stderr=PIPE).communicate()[0].split("\n")
 


### PR DESCRIPTION
Specifically '-l' and '--max-count' are mutually exclusive on Yosemite, and without this the 'ack' backend won't ever return results for search queries!