### PR TITLE
Another small fix for ack

### DIFF
--- a/pythonx/vim_pad/handler.py
+++ b/pythonx/vim_pad/handler.py
@@ -130,7 +130,7 @@ def listdir_external(path, archive, query): # {{{1
         command = [ack_path, query, path, "--noheading", "-l"]
         if archive != "!":
             command.append("--ignore-dir=archive")
-        command.append('--ignore-file=match:/\./')
+        command.append('--ignore-file=match:/^\./')
     elif search_backend == "ag":
         if vim.eval("executable('ag')") == "1":
             command = ["ag", query, path, "--noheading", "-l"]


### PR DESCRIPTION
Was the intention to exclude searching through `.`? If so ack doesn't search this by default, but just in case I added a $ to the start since the search had the unintended side effect of skipping *all* files with a dot in their name.