### PR TITLE
Allow passing list of directories to exclude

### DIFF
--- a/doc/pad.txt
+++ b/doc/pad.txt
@@ -241,6 +241,15 @@ the note title. The renames are done automatically when you leave/close a note.
 If you do not want vim-pad to rename the files you can set *g:pad#rename_files*
 to 0.
 
+Directories can be excluded from being searched by setting
+*g:pad#exclude_dirnames* to a comma separated string of directory names. e.g.:
+
+    let g:pad#exclude_dirnames = "img,assets"
+
+In the above example, directories with the names `img` or `assets` will be
+ignored anywhere in the directory heirarchy.  This is useful if you want to
+include media and non-text files in your notes directory.
+
 FUNCTIONS                                              *vim-pad-functions*
 ---------
 

--- a/plugin/pad.vim
+++ b/plugin/pad.vim
@@ -76,6 +76,9 @@ endif
 if !exists('g:pad#query_dirnames')
     let g:pad#query_dirnames = 1
 endif
+if !exists('g:pad#exclude_dirnames')
+    let g:pad#exclude_dirnames = ''
+endif
 " Display: {{{2
 if !exists('g:pad#read_nchars_from_files')
     let g:pad#read_nchars_from_files = 200

--- a/pythonx/pad/collator.py
+++ b/pythonx/pad/collator.py
@@ -24,7 +24,7 @@ class NotesSource(object):
         """
         pass
 
-    def __list_recursive_nohidden(self, use_archive=False, path=None):
+    def __list_recursive_nohidden(self, use_archive=False, exclude_dirnames=[], path=None):
         if path == None:
             path = self.path()
 
@@ -36,6 +36,10 @@ class NotesSource(object):
                 if use_archive == False:
                     if dirname == "archive":
                         dirnames.remove(dirname)
+                for excluded in exclude_dirnames:
+                    if dirname == excluded:
+                        dirnames.remove(dirname)
+
             matches += [join(root, f) for f in filenames if not f.startswith('.')]
         return matches
 
@@ -79,8 +83,9 @@ class NotesSource(object):
         return list(filter(lambda i: i != "", cmd_output))
 
     def query(self, query=None, use_archive=False):
+        exclude_dirnames = get_setting('exclude_dirnames').split(',')
         if not query or query == "":
-            files = self.__list_recursive_nohidden(use_archive)
+            files = self.__list_recursive_nohidden(use_archive, exclude_dirnames)
         else:
             query_filenames = get_setting('query_filenames', bool)
             query_dirnames = get_setting('query_dirnames', bool)
@@ -99,7 +104,8 @@ class NotesSource(object):
                         filter(isdir, glob(join(self.path(), "*"+ query+"*"))))
                 for mdir in matching_dirs:
                     files.extend(filter(lambda x: x not in files, \
-                            self.__list_recursive_nohidden(use_archive, mdir)))
+                            self.__list_recursive_nohidden(use_archive,
+                                                           exclude_dirnames, mdir)))
 
         if version_info.major == 2:
             return map(lambda x: x.encode('utf-8') if isinstance(x, unicode) else x, files)

--- a/pythonx/pad/plugin.py
+++ b/pythonx/pad/plugin.py
@@ -127,7 +127,7 @@ class PadPlugin(object): #{{{1
                 if raw_char == "13":
                     if should_create_on_enter:
                         if should_open == True:
-                            open_pad(first_line=query)
+                            self.open(first_line=query)
                         else:
                             path = join(get_save_dir(), \
                                     PadInfo([query]).id + \
@@ -136,7 +136,7 @@ class PadPlugin(object): #{{{1
                                 new_note.write(query)
                         V + "echohl None"
                     else:
-                        display(query, True)
+                        self.display(query, True)
                 V + "redraw!"
                 break
             else:
@@ -158,6 +158,6 @@ class PadPlugin(object): #{{{1
                 V + "echohl WarningMsg"
                 should_create_on_enter = True
             V + "redraw"
-            v + ('echo ">> ' + info + query + '"')
+            V + ('echo ">> ' + info + query + '"')
 
 # vim: set fdm=marker :


### PR DESCRIPTION
This adds the variable `g:pad#exclude_dirnames` to allow particular folders to be ignored.  The primary use case is when a someone wishes to exclude directories that may contain images or other non-text files.  Please see the additions to the docs for more information.

I also fixed a few little bugs in `plugin.py` which had broken the `global_incremental_search` function.