### PR TITLE
rename pad tutorial

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -219,5 +219,5 @@ can read a tutorial on using vim-pad (it is basically equivalent to this
 README, but with exercises) with
 
 ~~~ vim
-    :Tutor vim-pad
+    :Tutor pad
 ~~~


### PR DESCRIPTION
Tutorial was renamed from vim-pad to pad in f1a5402306eb079b280bb9cb8f8779b3874baedf but README.mkd has not been updated.