### PR TITLE
Correctly generate the warning if vim-pad mappings conflict

### DIFF
--- a/plugin/pad.vim
+++ b/plugin/pad.vim
@@ -173,7 +173,7 @@ function! s:CreateMapping(key, action, ...) "{{{2
             execute "silent " . l:mode . " <unique> " . l:key . " <Plug>(" . a:action . ")"
         catch /E227/
             if g:pad#silent_on_mappings_fail < 1
-                echom "[vim-pad] " . l:key . " in " . l:mode_idx == 1? "normal" : "insert" . " mode is already mapped."
+                echom "[vim-pad] " . l:key . " in " . (l:mode_idx == 1 ? "normal" : "insert") . " mode is already mapped."
             endif
         endtry
     endfor


### PR DESCRIPTION
I'm not sure how the code got this way, but it appears that previously the entire first half of the warning message was taken as the condition for the ternary that chooses between "normal" and "insert" for the message, meaning you always get the useless message "insert mode is already mapped", no matter which mode was already mapped. Very confusing!

This patch simply puts parentheses around the ternary expression so that the warning messages are generated as intended.